### PR TITLE
Code style and efficiency changes to laserbeamFoam

### DIFF
--- a/applications/solvers/laserbeamFoam/UEqn.H
+++ b/applications/solvers/laserbeamFoam/UEqn.H
@@ -1,51 +1,58 @@
 MRF.correctBoundaryVelocity(U);
 
-dimensionedScalar DarcyConstantlarge("DarcyConstantlarge",dimensionSet(1,-3,-1,0,0),scalar(1.0e6));//1e10
-dimensionedScalar DarcyConstantsmall("DarcyConstantsmall",dimensionSet(0,0,0,0,0),scalar(1.0e-12));//1e-6
-
-// dimensionedScalar TSmooth("TSmooth",dimensionSet(0, 0, 0, 1, 0),50.0);
-
-
-
 if (laser.powderSim())
 {
-    DC = (DarcyConstantlarge*Foam::pow((1.0-epsilon1mask),2)/(Foam::pow(epsilon1mask,3)+DarcyConstantsmall));
+    DC =
+        DarcyConstantlarge*Foam::pow((1.0-epsilon1mask),2)
+       /(Foam::pow(epsilon1mask, 3) + DarcyConstantsmall);
 }
 else
 {
-    DC = (DarcyConstantlarge*Foam::pow((1.0-epsilon1),2)/(Foam::pow(epsilon1,3)+DarcyConstantsmall));
+    DC =
+        DarcyConstantlarge*Foam::pow((1.0 - epsilon1), 2)
+       /(Foam::pow(epsilon1, 3) + DarcyConstantsmall);
 }
-const volVectorField gradAlpha(fvc::grad(alpha1));
 
-const volVectorField nHatM(gradAlpha/(mag(gradAlpha) + deltaN));
-Marangoni = epsilon1*Marangoni_Constant*(gradT-nHatM*(nHatM & gradT))*mag(gradAlpha);
+gradAlpha = fvc::grad(alpha1);
 
-forAll( mesh.C(), celli)
+nHatM = gradAlpha/(mag(gradAlpha) + deltaN);
+
+Marangoni =
+    epsilon1*Marangoni_Constant*(gradT - nHatM*(nHatM & gradT))*mag(gradAlpha);
+
+const scalar Tliquidus1Value = Tliquidus1.value();
+const scalarField& TI = T;
+vectorField& MarangoniI = Marangoni;
+forAll(MarangoniI, celli)
 {
-if(T[celli]<Tliquidus1.value()){
-
-    Marangoni[celli]*=0.0;
+    if(TI[celli] < Tliquidus1Value)
+    {
+        MarangoniI[celli] = vector::zero;
+    }
 }
 
-}
-if(damperSwitch)
+Marangoni.correctBoundaryConditions();
+
+if (damperSwitch)
 {
-    damper = 2.0 * rho /(rho1+rho2); //To account for high density difference
+    // To account for high density difference
+    damper = 2.0*rho/(rho1 + rho2);
 }
 
-pVap = /*min(max((T-(Tvap-(TSmooth/2.0)))/TSmooth,0.0),1.0)*/ 0.54 * p0 * Foam::exp(LatentHeatVap*Mm*((T-Tvap)/(R*T*Tvap)));
+pVap = 0.54*p0*Foam::exp(LatentHeatVap*Mm*((T - Tvap)/(R*T*Tvap)));
 
 fvVectorMatrix UEqn
 (
-    fvm::ddt(rho, U) + fvm::div(rhoPhi, U)
-    + MRF.DDt(rho, U)
-    + turbulence.divDevTau(rho, U)
-    + fvm::Sp(DC, U)
-    - Marangoni*damper
-    ==
+    fvm::ddt(rho, U)
+  + fvm::div(rhoPhi, U)
+  + MRF.DDt(rho, U)
+  + turbulence.divDevTau(rho, U)
+  + fvm::Sp(DC, U)
+  - Marangoni*damper
+ ==
     phaseChange.SU(rho, rhoPhi, U)
-    + fvModels.source(rho, U)
-    );
+  + fvModels.source(rho, U)
+);
 
 UEqn.relax();
 
@@ -56,15 +63,17 @@ if (pimple.momentumPredictor())
     solve
     (
         UEqn
-        ==
+     ==
         fvc::reconstruct
         (
             (
                 mixture.surfaceTensionForce()*fvc::interpolate(damper)
-                +fvc::interpolate(pVap)*fvc::snGrad(alpha1)*fvc::interpolate(damper)
-                - ghf*fvc::snGrad(rho*rhok)
-                - fvc::snGrad(p_rgh)
-            ) * mesh.magSf()
+              + fvc::interpolate(pVap)
+               *fvc::snGrad(alpha1)
+               *fvc::interpolate(damper)
+              - ghf*fvc::snGrad(rho*rhok)
+              - fvc::snGrad(p_rgh)
+            )*mesh.magSf()
         )
     );
 

--- a/applications/solvers/laserbeamFoam/createFields.H
+++ b/applications/solvers/laserbeamFoam/createFields.H
@@ -718,3 +718,17 @@ surfaceScalarField rhoPhi("rhoPhi", fvc::interpolate(rho)*phi);
 surfaceScalarField rhophicp(fvc::interpolate(cp)*rhoPhi);
 
 #include "updateProps.H"
+
+const dimensionedScalar DarcyConstantlarge
+(
+    "DarcyConstantlarge", dimensionSet(1,-3,-1,0,0), 1.0e6
+);
+
+const dimensionedScalar DarcyConstantsmall
+(
+    "DarcyConstantsmall", dimensionSet(0,0,0,0,0), 1.0e-12
+);
+
+volVectorField gradAlpha(fvc::grad(alpha1));
+
+volVectorField nHatM(gradAlpha/(mag(gradAlpha) + deltaN));

--- a/applications/solvers/laserbeamFoam/createFields.H
+++ b/applications/solvers/laserbeamFoam/createFields.H
@@ -662,6 +662,10 @@ volScalarField alpha_filtered
     dimensionedScalar("alpha_filtered", dimensionSet(0, 0, 0, -0, 0), 0.0)
 );
 
+volVectorField gradepsilon1(fvc::grad(alpha_filtered));
+volScalarField e1temp(fvc::average(epsilon1));
+volScalarField e2temp(fvc::average(epsilon1mask));
+
 dimensionedScalar elec_resistivity_metal
 (
     "elec_resistivity",

--- a/applications/solvers/laserbeamFoam/readControls.H
+++ b/applications/solvers/laserbeamFoam/readControls.H
@@ -3,20 +3,27 @@ IOdictionary solutionDict
     IOobject
     (
         "fvSolution",
-        runTime.system(), //folder where the fvSolution file is located
+        runTime.system(),
         runTime,
         IOobject::MUST_READ
     )
 );
 
-
-
 dictionary& meltingDict = solutionDict.subDict("MELTING");
 
-int minTCorr(readLabel(meltingDict.lookup("minTempCorrector")));
-int maxTCorr(readLabel(meltingDict.lookup("maxTempCorrector")));
+const label minTCorr(readLabel(meltingDict.lookup("minTempCorrector")));
 
-dimensionedScalar epsilonTol(readScalar(meltingDict.lookup("epsilonTolerance")));
-dimensionedScalar epsilonRel(readScalar(meltingDict.lookup("epsilonRelaxation")));
+const label maxTCorr(readLabel(meltingDict.lookup("maxTempCorrector")));
 
-bool damperSwitch = meltingDict.lookupOrDefault<bool>("damperSwitch", false);
+const dimensionedScalar epsilonTol
+(
+    readScalar(meltingDict.lookup("epsilonTolerance"))
+);
+
+const dimensionedScalar epsilonRel
+(
+    readScalar(meltingDict.lookup("epsilonRelaxation"))
+);
+
+const bool damperSwitch =
+    meltingDict.lookupOrDefault<bool>("damperSwitch", false);

--- a/applications/solvers/laserbeamFoam/updateProps.H
+++ b/applications/solvers/laserbeamFoam/updateProps.H
@@ -1,161 +1,153 @@
-
-// cp=(epsilon1*(alpha1*cp1 + (1.0-alpha1)*cp2)) + ((1.0-epsilon1)*(alpha1*cp1solid + (1.0-alpha1)*cp2solid));
-// kappa=(epsilon1*(alpha1*kappa1 + (1.0-alpha1)*kappa2)) + ((1.0-epsilon1)*(alpha1*kappa1solid + (1.0-alpha1)*kappa2solid));
-TSolidus=alpha1*Tsolidus1 + (1.0-alpha1)*Tsolidus2;
-TLiquidus=alpha1*Tliquidus1 + (1.0-alpha1)*Tliquidus2;
-// LatentHeat=alpha1*LatentHeat1 + (1.0-alpha1)*LatentHeat2;
-beta=alpha1*beta1 + (1.0-alpha1)*beta2;
-
-rhok=(1.0-max(epsilon1*(beta)*(T-TSolidus),0.0));
-rhok.correctBoundaryConditions();
-
-forAll( mesh.C(), celli)
 {
-if(alpha1[celli]>0.05){
-TSolidus[celli]=Tsolidus1.value();
-TLiquidus[celli]=Tliquidus1.value();
-}
-}
+    TSolidus = alpha1*Tsolidus1 + (1.0 - alpha1)*Tsolidus2;
+    TLiquidus = alpha1*Tliquidus1 + (1.0 - alpha1)*Tliquidus2;
+    beta = alpha1*beta1 + (1.0 - alpha1)*beta2;
+    rhok = (1.0 - max(epsilon1*(beta)*(T - TSolidus), 0.0));
 
-forAll( mesh.C(), celli)
-{
-kappa[celli]=(max(min(alpha1[celli],1.0),0.0)*(polykappa_m.value(T[celli])))+((1.0-max(min(alpha1[celli],1.0),0.0))*polykappa_g.value(T[celli]));
-cp[celli]=(max(min(alpha1[celli],1.0),0.0)*(polycp_m.value(T[celli])))+((1.0-max(min(alpha1[celli],1.0),0.0))*polycp_g.value(T[celli]));
-}
-
-kappa.correctBoundaryConditions();
-
-
-
-
-
-//update the cell size fields
-const faceList & ff = mesh.faces();
-const pointField & pp = mesh.points();
-
-const vectorField& CI = mesh.C();
-scalarField& yDimI = laser.yDim();
-
-forAll(CI, celli)
-{
-    // vector XYZ = mesh.C()[celli];
-    // xcoord[celli]=XYZ.x();
-    // zcoord[celli]=XYZ.z();
-
-    const cell& cc = mesh.cells()[celli];
-    labelList pLabels(cc.labels(ff));
-    pointField pLocal(pLabels.size(), vector::zero);
-
-    forAll(pLabels, pointi)
+    scalarField& alpha1I = alpha1;
+    scalarField& TSolidusI = TSolidus;
+    scalarField& TLiquidusI = TLiquidus;
+    const scalar Tsolidus1Value = Tsolidus1.value();
+    const scalar Tliquidus1Value = Tliquidus1.value();
+    forAll(alpha1I, celli)
     {
-        pLocal[pointi] = pp[pLabels[pointi]];
-    }
-
-    // xDim[celli] = Foam::max(pLocal & vector(1,0,0)) - Foam::min(pLocal & vector(1,0,0));
-    yDimI[celli] = Foam::max(pLocal & vector(0,1,0)) - Foam::min(pLocal & vector(0,1,0));
-    // zDim[celli] = Foam::max(pLocal & vector(0,0,1)) - Foam::min(pLocal & vector(0,0,1));
-}
-
-// xDim.correctBoundaryConditions();
-laser.yDim().correctBoundaryConditions();
-// zDim.correctBoundaryConditions();
-//update the cell size fields
-
-
-
-
-
-
-
-
-
-
-// refineflag=fvc::average(alpha1);
-metalaverage = fvc::average(alpha1);
-
-laser.refineFlag() *= 0.0;
-laser.refineFlag() += metalaverage;
-
-// forAll( mesh.C(), celli)
-// {
-// if((metalaverage[celli]>0.1&&metalaverage[celli]<0.9)||refineflag2[celli]>0.1){
-// refineflag2[celli]=0.5;
-// }
-// }
-
-alpha_filtered=alpha1;
-
-forAll(CI, celli)
-{
-    if (alpha1[celli] > 0.99)
-    {
-
-        alpha_filtered[celli]=1.0;
-
-    }
-    else
-    {
-
-        if(alpha1[celli]<0.01)
+        if (alpha1I[celli] > 0.05)
         {
+            TSolidusI[celli] = Tsolidus1Value;
+            TLiquidusI[celli] = Tliquidus1Value;
+        }
+    }
 
-            alpha_filtered[celli]=0.0;
+    TSolidus.correctBoundaryConditions();
+    TLiquidus.correctBoundaryConditions();
 
+    scalarField& kappaI = kappa;
+    scalarField& cpI = cp;
+    const scalarField& TI = T;
+    forAll(kappaI, celli)
+    {
+        kappaI[celli] =
+            (
+                max(min(alpha1I[celli], 1.0), 0.0)
+               *(polykappa_m.value(TI[celli]))
+            )
+          + (
+                (1.0 - max(min(alpha1I[celli], 1.0), 0.0))
+               *polykappa_g.value(TI[celli])
+            );
+
+        cpI[celli] =
+            (
+                max(min(alpha1I[celli], 1.0), 0.0)
+               *polycp_m.value(TI[celli])
+            )
+          + (
+                (1.0 - max(min(alpha1I[celli], 1.0), 0.0))
+               *polycp_g.value(TI[celli])
+            );
+    }
+
+    kappa.correctBoundaryConditions();
+    cp.correctBoundaryConditions();
+
+
+    // Update the cell size fields
+    const faceList & ff = mesh.faces();
+    const pointField & pp = mesh.points();
+    const vectorField& CI = mesh.C();
+    scalarField& yDimI = laser.yDim();
+    forAll(CI, celli)
+    {
+        const cell& cc = mesh.cells()[celli];
+        labelList pLabels(cc.labels(ff));
+        pointField pLocal(pLabels.size(), vector::zero);
+
+        forAll(pLabels, pointi)
+        {
+            pLocal[pointi] = pp[pLabels[pointi]];
+        }
+
+        yDimI[celli] =
+            Foam::max(pLocal & vector(0, 1, 0))
+          - Foam::min(pLocal & vector(0, 1, 0));
+    }
+
+    laser.yDim().correctBoundaryConditions();
+
+    metalaverage = fvc::average(alpha1);
+    laser.refineFlag() *= 0.0;
+    laser.refineFlag() += metalaverage;
+
+    alpha_filtered = volScalarField("alpha_filtered", alpha1);
+
+    scalarField& alpha_filteredI = alpha_filtered;
+    forAll(CI, celli)
+    {
+        if (alpha1I[celli] > 0.99)
+        {
+            alpha_filteredI[celli] = 1.0;
         }
         else
         {
-            alpha_filtered[celli]=alpha1[celli];
+            if (alpha1I[celli] < 0.01)
+            {
+                alpha_filteredI[celli] = 0.0;
+            }
+            else
+            {
+                alpha_filteredI[celli] = alpha1I[celli];
+            }
+        }
+    }
+
+    alpha_filtered.correctBoundaryConditions();
+
+    LatentHeat =
+        alpha_filtered*LatentHeat1 + (1.0 - alpha_filtered)*LatentHeat2;
+
+    gradepsilon1 = fvc::grad(alpha_filtered);
+
+    n_filtered = fvc::grad(alpha_filtered)/((mag(gradepsilon1) + deltaN));
+
+    e1temp = fvc::average(epsilon1);
+
+    const scalarField& e1tempI = e1temp;
+    const scalarField& epsilon1I = epsilon1;
+    scalarField& epsilon1maskI = epsilon1mask;
+    forAll(CI, celli)
+    {
+        if (e1tempI[celli] <= 0.95)
+        {
+            epsilon1maskI[celli] = 0.0;
+        }
+        else
+        {
+            epsilon1maskI[celli] = epsilon1I[celli];
+        }
+    }
+
+    epsilon1mask.correctBoundaryConditions();
+
+    e2temp = fvc::average(epsilon1mask);
+    epsilon1mask2 *= 0.0;
+
+    const scalarField& e2tempI = e2temp;
+    scalarField& epsilon1mask2I = epsilon1mask2;
+    forAll(CI, celli)
+    {
+        if (e2tempI[celli] <= 0.95)
+        {
+            epsilon1mask2I[celli] = 0.0;
+        }
+        else
+        {
+            epsilon1mask2I[celli] = epsilon1maskI[celli];
         }
 
     }
+
+    epsilon1mask2.correctBoundaryConditions();
+
+    gh = epsilon1mask*(g & mesh.C());
+    ghf = fvc::interpolate(epsilon1mask)*(g & mesh.Cf());
 }
-alpha_filtered.correctBoundaryConditions();
-
-LatentHeat=alpha_filtered*LatentHeat1 + (1.0-alpha_filtered)*LatentHeat2;
-
-volVectorField gradepsilon1(fvc::grad(alpha_filtered));
-
-gradepsilon1.correctBoundaryConditions();
-
-n_filtered = fvc::grad(alpha_filtered)/((mag(gradepsilon1) + deltaN));
-
-n_filtered.correctBoundaryConditions();
-
-// volScalarField 
-epsilon1.correctBoundaryConditions();
-volScalarField e1temp(fvc::average(epsilon1));
-
-e1temp.correctBoundaryConditions();
-
-forAll(CI, celli)
-{
-    if(e1temp[celli]<=0.95)
-    {
-        epsilon1mask[celli]=0.0;
-    }
-    else
-    {
-        epsilon1mask[celli]=epsilon1[celli];
-    }
-
-}
-
-epsilon1mask.correctBoundaryConditions();
-
-volScalarField e2temp(fvc::average(epsilon1mask));
-epsilon1mask2*=0.0;
-forAll(CI, celli)
-{
-    if(e2temp[celli]<=0.95)
-    {
-        epsilon1mask2[celli]=0.0;
-    }
-    else
-    {
-        epsilon1mask2[celli]=epsilon1mask[celli];
-    }
-
-}
-
-gh = epsilon1mask*(g & mesh.C());
-ghf = fvc::interpolate(epsilon1mask)*(g & mesh.Cf());


### PR DESCRIPTION
- confirm code to the OpenFOAM style guide
- avoid the allocation of large memory objects within the time loop
- directly access internal fields inside loops to avoid unnecessary function calls

These changes should not affect the answers - just the speed (probably very minor)



You will notice I am suddenly on a laserbeamFoam buzz :P