### PR TITLE
Added extra variables to store the cells that have been liquid at least once.

### DIFF
--- a/applications/solvers/laserbeamFoam/createFields.H
+++ b/applications/solvers/laserbeamFoam/createFields.H
@@ -655,3 +655,33 @@ const dimensionedScalar DarcyConstantsmall
 volVectorField gradAlpha(fvc::grad(alpha1));
 
 volVectorField nHatM(gradAlpha/(mag(gradAlpha) + deltaN));
+
+// This variable is >=0 if the cell has been liquid
+volScalarField meltHistory
+(
+    IOobject
+    (
+        "meltHistory",
+        runTime.timeName(),
+        mesh,
+        IOobject::NO_READ,
+        IOobject::AUTO_WRITE
+    ),
+    mesh,
+    dimensionedScalar("meltHistory", dimensionSet(0, 0, 0, -0, 0), 0.0)
+);
+
+// This variable is 1 if (alpha.metal >= 0.5 and epsilon1 >=0.5), 0 otherwise
+volScalarField condition
+(
+    IOobject
+    (
+        "condition",
+        runTime.timeName(),
+        mesh,
+        IOobject::NO_READ,
+        IOobject::AUTO_WRITE
+    ),
+    mesh,
+    dimensionedScalar("condition", dimensionSet(0, 0, 0, -0, 0), 0.0)
+);

--- a/applications/solvers/laserbeamFoam/laserbeamFoam.C
+++ b/applications/solvers/laserbeamFoam/laserbeamFoam.C
@@ -213,6 +213,12 @@ int main(int argc, char *argv[])
             }
         }
 
+        // Check the cells that have melted
+        volScalarField alphaMetal = 
+            mesh.lookupObject<volScalarField>("alpha.metal");
+        condition = pos(alphaMetal - 0.5) * pos(epsilon1 - 0.5);
+        meltHistory += condition;
+
         runTime.write();
 
         Info<< "ExecutionTime = " << runTime.elapsedCpuTime() << " s"


### PR DESCRIPTION
The main code has an extra field (meltHistory) with two different values in the cells:
a) 0 if the cell has never been liquid during the simulation
b) >0 otherwise

At postprocessing time, this means that cells with (meltHistory > 0) represent the melt pool and we can post-process them with automated utilities to extract the geometric features.  