### PR TITLE
Fix laserbeamFoam temperature corrector loop bound

### DIFF
--- a/applications/solvers/laserbeamFoam/TEqn.H
+++ b/applications/solvers/laserbeamFoam/TEqn.H
@@ -123,7 +123,7 @@
          // || (meanResidual > epsilonTol.value())
          || (maxResidual > epsilonTol.value())
         )
-     && iter <= maxTCorr
+     && iter < maxTCorr
     );
 
     gradT = fvc::grad(T);


### PR DESCRIPTION
Created by Codex.

## Summary
- fix the off-by-one condition in the temperature corrector loop
- ensure `maxTempCorrector` is enforced as a true upper bound on the number of temperature solves

## Testing
- not run