### PR TITLE
Optimize laserbeamFoam yDim refresh

### DIFF
--- a/applications/solvers/laserbeamFoam/MULES/firstIter.H
+++ b/applications/solvers/laserbeamFoam/MULES/firstIter.H
@@ -4,6 +4,8 @@ if (pimple.firstIter() || moveMeshOuterCorrectors)
 
     if (mesh.changing())
     {
+        #include "updateYDim.H"
+
         // Do not apply previous time-step mesh compression flux
         // if the mesh topology changed
         if (mesh.topoChanging())

--- a/applications/solvers/laserbeamFoam/createFields.H
+++ b/applications/solvers/laserbeamFoam/createFields.H
@@ -781,6 +781,7 @@ autoPtr<transportModelType> turbulence
 // Create laser heat source
 laserHeatSource laser(mesh);
 
+#include "updateYDim.H"
 #include "updateProps.H"
 
 // volScalarField depositionTemp

--- a/applications/solvers/laserbeamFoam/isoAdvector/firstIter.H
+++ b/applications/solvers/laserbeamFoam/isoAdvector/firstIter.H
@@ -9,6 +9,8 @@ if (pimple.firstIter() || moveMeshOuterCorrectors)
 
     if (mesh.changing())
     {
+        #include "updateYDim.H"
+
         gh = (g & mesh.C()) - ghRef;
         ghf = (g & mesh.Cf()) - ghRef;
 

--- a/applications/solvers/laserbeamFoam/updateProps.H
+++ b/applications/solvers/laserbeamFoam/updateProps.H
@@ -25,29 +25,7 @@
 
     #include "updateKappaCp.H"
 
-    // Update the cell size fields
-    const faceList & ff = mesh.faces();
-    const pointField & pp = mesh.points();
     const vectorField& CI = mesh.C();
-    scalarField& yDimI = laser.yDim();
-    forAll(CI, celli)
-    {
-        const cell& cc = mesh.cells()[celli];
-        labelList pLabels(cc.labels(ff));
-        pointField pLocal(pLabels.size(), vector::zero);
-
-        forAll(pLabels, pointi)
-        {
-            pLocal[pointi] = pp[pLabels[pointi]];
-        }
-
-        yDimI[celli] =
-            Foam::max(pLocal & vector(0, 1, 0))
-          - Foam::min(pLocal & vector(0, 1, 0));
-    }
-
-    laser.yDim().correctBoundaryConditions();
-
     metalaverage = fvc::average(alpha1);
     metalaverage.correctBoundaryConditions();  // ADDED
 

--- a/applications/solvers/laserbeamFoam/updateYDim.H
+++ b/applications/solvers/laserbeamFoam/updateYDim.H
@@ -1,0 +1,25 @@
+if (!laser.radialPolarHeatSource())
+{
+    const faceList& ff = mesh.faces();
+    const pointField& pp = mesh.points();
+    const vectorField& CI = mesh.C();
+    scalarField& yDimI = laser.yDim();
+
+    forAll(CI, celli)
+    {
+        const cell& cc = mesh.cells()[celli];
+        labelList pLabels(cc.labels(ff));
+        pointField pLocal(pLabels.size(), vector::zero);
+
+        forAll(pLabels, pointi)
+        {
+            pLocal[pointi] = pp[pLabels[pointi]];
+        }
+
+        yDimI[celli] =
+            Foam::max(pLocal & vector(0, 1, 0))
+          - Foam::min(pLocal & vector(0, 1, 0));
+    }
+
+    laser.yDim().correctBoundaryConditions();
+}


### PR DESCRIPTION
Created by Codex.

## Summary
- move the expensive `yDim` geometry update into a shared helper
- initialize `yDim` at startup and refresh it only when the mesh changes
- skip `yDim` refreshes when `radialPolarHeatSource` is enabled

## Testing
- built successfully with OpenFOAM-v2512 using `./Allwmake -j`
- verified `tutorials/laserbeamFoam/Plate2D` starts correctly and advances through early timesteps