### PR TITLE
Add Codex skill and initial regression test harness

### DIFF
--- a/.agents/skills/laserbeamfoam/SKILL.md
+++ b/.agents/skills/laserbeamfoam/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: laserbeamfoam
+description: >
+  Use this skill for any task involving the LaserbeamFoam repository: editing
+  the laserbeamFoam or compressibleLaserbeamFoam solvers, modifying the custom
+  ray-tracing or geometric VOF libraries, updating transport or turbulence
+  models, adjusting OpenFOAM build files, or changing tutorial cases. Trigger
+  whenever the user mentions laserbeamFoam, LaserbeamFoam, laserHeatSource,
+  compressibleLaserbeamFoam, laserMeltFoam, geometricVoF, or requests C++ or
+  OpenFOAM changes in this codebase.
+---
+
+# Codex Guidelines for LaserbeamFoam
+
+This document defines how automated coding changes should be made in this
+repository.
+
+## 1) Core Principles
+
+- Make the smallest correct change.
+- Preserve existing OpenFOAM-style architecture and naming patterns.
+- Prefer consistency with nearby solver or library code over introducing a new
+  style.
+- Avoid broad refactors unless explicitly requested.
+- Keep supported OpenFOAM version compatibility in mind.
+
+## 2) Repository Scope
+
+This repository is a suite of OpenFOAM-based solvers and libraries for
+laser-material interaction problems, including:
+
+- `laserbeamFoam`
+- `compressibleLaserbeamFoam`
+- `laserMeltFoam`
+- custom libraries under `src/` for:
+  - geometric VOF / interface reconstruction
+  - laser ray-tracing heat source modelling
+  - transport models
+  - turbulence models
+
+The build entry point is the root [`Allwmake`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/Allwmake),
+which currently checks for OpenFOAM versions `v2412`, `v2506`, and `v2512`.
+
+## 3) Coding Style Rules
+
+### C++ style
+
+- Follow existing OpenFOAM / repository style in surrounding files.
+- Use the same indentation, brace style, comment style, and naming conventions
+  as nearby code.
+- Keep expressions readable; avoid compact or clever rewrites.
+- Prefer explicit local changes over abstraction-heavy redesigns.
+- Add comments only when behaviour is non-obvious.
+
+### Headers and includes
+
+- Preserve the existing license/header block format in C++ files.
+- Keep include ordering aligned with nearby files.
+- Do not change copyright or license text unless explicitly requested.
+
+### Scripts and docs
+
+- Match existing shell style in `Allwmake`, `Allwclean`, `Allrun`, `Allclean`,
+  and tutorial helper scripts.
+- Keep Markdown concise, practical, and repository-specific.
+- Do not rewrite documentation just to restyle it.
+
+## 4) OpenFOAM Conventions to Follow
+
+- Respect runtime type and selection table conventions:
+  - `TypeName("...")` in headers
+  - `defineTypeNameAndDebug(...)` where appropriate
+  - `addToRunTimeSelectionTable(...)` in source files for selectable models
+- Preserve dictionary-driven behaviour and runtime configurability.
+- Keep field naming and dimension handling consistent with existing solver code.
+- Avoid introducing dependencies that break `wmake` / `Allwmake` workflows.
+- When adding source files, update the relevant `Make/files` in the same
+  module.
+
+Examples of runtime-selectable code in this repository include:
+
+- viscosity models in
+  [`src/transportModels/incompressible/viscosityModels`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/transportModels/incompressible/viscosityModels)
+- transport model factories in
+  [`src/transportModels/incompressible`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/transportModels/incompressible)
+- turbulence model factories in
+  [`src/turbulenceModel`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/turbulenceModel)
+
+Rules when adding a new runtime-selectable class:
+
+- Add `TypeName("...")` in the header.
+- Register the type in the matching source file when the module uses a runtime
+  selection table.
+- Add the source file to the relevant `Make/files`.
+- Ensure the dictionary `type` string matches the registered class name.
+
+## 5) Solver and Library Patterns
+
+When editing the main solvers, preserve the existing split-header structure:
+
+- solver entry point in `*.C`
+- field creation in `createFields.H`
+- momentum equation in `UEqn.H`
+- pressure equation in `pEqn.H`
+- energy equation in `TEqn.H`
+- property updates in files such as `updateProps.H`, `updateKappaCp.H`, or
+  `update.H`
+- VOF controls under solver-local `MULES/`, `isoAdvector/`, or `VoF/`
+  directories
+
+When editing laser deposition logic:
+
+- Prefer keeping ray-tracing behaviour in the `laserHeatSource` library rather
+  than pushing detail into solver loops.
+- Preserve dictionary-based laser configuration from `constant/LaserProperties`
+  and time-series inputs such as `timeVsLaserPosition` and
+  `timeVsLaserPower`.
+- Be careful with changes that affect ray-path VTK output or deposition field
+  coupling into `TEqn.H`.
+
+When editing geometric VOF code:
+
+- Follow existing separation between reconstruction schemes, sampled
+  interfaces, surface iterators, and advection code.
+- Avoid mixing solver-specific logic into the generic `src/geometricVoF`
+  library.
+
+## 6) Build and Test Workflow
+
+Preferred workflow:
+
+1. Read nearby code and match local patterns.
+2. Make the minimum patch necessary.
+3. Update `Make/files` or `Make/options` if required.
+4. Build the narrowest relevant target first when possible.
+5. Run the most relevant tutorial, utility, or compile check available.
+
+Typical build entry points:
+
+- root build: [`Allwmake`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/Allwmake)
+- library build: [`src/Allwmake`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/Allwmake)
+- application build: [`applications/Allwmake`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/applications/Allwmake)
+- compressible solver-specific build:
+  [`applications/solvers/compressibleLaserbeamFoam/Allwmake`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/applications/solvers/compressibleLaserbeamFoam/Allwmake)
+
+Relevant regression surfaces usually include tutorial cases under
+[`tutorials`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/tutorials),
+especially:
+
+- `tutorials/laserbeamFoam/...`
+- `tutorials/compressiblelaserbeamFoam/...`
+- `tutorials/multiComponentlaserbeamFoam/...`
+- `tutorials/laserMeltFoam/...`
+
+## 7) Minimise Changes
+
+- Only modify files necessary for the requested task.
+- Do not reformat unrelated code.
+- Do not rename files or symbols unless required.
+- Do not change solver behaviour outside requested scope.
+- Prefer targeted fixes over opportunistic cleanup.
+
+Before finalizing, verify:
+
+- build impact is localized
+- only relevant files changed
+- no solver branch or library registration was accidentally broken
+- dictionary interfaces remain compatible unless the user asked to change them
+
+## 8) What to Avoid
+
+- Large-scale refactors without explicit request.
+- Moving code between solver and library layers without clear need.
+- Introducing new coding conventions inconsistent with the repo.
+- Silent changes to case dictionary interfaces.
+- Updating tutorial inputs as a side effect of solver edits unless necessary.
+
+## 9) Reference Files
+
+- Main incompressible solver:
+  [`applications/solvers/laserbeamFoam/laserbeamFoam.C`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/applications/solvers/laserbeamFoam/laserbeamFoam.C)
+- Main compressible solver:
+  [`applications/solvers/compressibleLaserbeamFoam/compressibleLaserbeamFoam.C`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/applications/solvers/compressibleLaserbeamFoam/compressibleLaserbeamFoam.C)
+- Laser heat source library:
+  [`src/laserHeatSource/laserHeatSource.H`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/laserHeatSource/laserHeatSource.H)
+  [`src/laserHeatSource/laserHeatSource.C`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/laserHeatSource/laserHeatSource.C)
+- Ray particle implementation:
+  [`src/laserHeatSource/laserRayParticle.H`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/laserHeatSource/laserRayParticle.H)
+  [`src/laserHeatSource/laserRayParticle.C`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/laserHeatSource/laserRayParticle.C)
+- Geometric VOF core:
+  [`src/geometricVoF/Make/files`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/geometricVoF/Make/files)
+  [`src/geometricVoF/reconstructionSchemes/reconstructionSchemes.H`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/geometricVoF/reconstructionSchemes/reconstructionSchemes.H)
+- Incompressible transport models:
+  [`src/transportModels/incompressible/Make/files`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/transportModels/incompressible/Make/files)
+- Turbulence model entry points:
+  [`src/turbulenceModel/turbulenceModelNew.H`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/turbulenceModel/turbulenceModelNew.H)
+  [`src/turbulenceModel/turbulenceModelNew.C`](/Users/philipc/code/laserbeamfoamProjects/LaserbeamFoam/src/turbulenceModel/turbulenceModelNew.C)

--- a/.agents/skills/laserbeamfoam/agents/openai.yaml
+++ b/.agents/skills/laserbeamfoam/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LaserbeamFoam"
+  short_description: "Work on LaserbeamFoam solvers and libraries"
+  default_prompt: "Use $laserbeamfoam to work on the LaserbeamFoam repository, following its solver, library, build, and tutorial conventions."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# Check the laserbeamFoam solvers compile correctly
-name: Build
+# Check the repository compiles correctly and Alltest-regression passes
+name: Build and test
 
 on:
   push:
@@ -37,14 +37,23 @@ jobs:
           cd tutorials
           ./Alltest
 
+      - name: Alltest-regression
+        shell: bash -l {0}
+        run: |
+          source ${{ matrix.container-image.source }}
+          cd tutorials
+          ./Alltest-regression
+
       - name: Upload test logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: test-logs.${{ matrix.container-image.name }}
-          path: tutorialsTest/logs
+          path: |
+            tutorialsTest/logs
+            tutorialsTest-regression
           retention-days: 10
 
       - name: Set job status
         if: ${{ failure() }}
-        run: echo "::error::Alltest failed, marking job as failed"
+        run: echo "::error::Alltest or Alltest-regression failed, marking job as failed"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Test directories
 tutorialsTest
+tutorialsTest-regression
 
 # VTK files
 *.vtk

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
   <img src="images/LBF.gif" alt="LBF gif" style="width:1000px;">
 </p>
 
+## Codex Skill
+
+This repository includes a repo-local Codex skill at
+`.agents/skills/laserbeamfoam/SKILL.md` for work on the `laserbeamFoam`
+codebase.
+
+To load it in Codex, reference it directly, for example:
+
+```text
+[$laserbeamfoam](.agents/skills/laserbeamfoam/SKILL.md)
+```
+
 ## Overview
 
 Presented here is a growing suite of solvers that describe the laser-substrate

--- a/tutorials/Alltest-regression
+++ b/tutorials/Alltest-regression
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+echo "============================================================"
+echo "laserbeamFoam regression tests"
+echo "============================================================"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}"
+REG_ROOT="${ROOT_DIR}/../tutorialsTest-regression"
+MAX_JOBS=""
+
+usage()
+{
+    cat <<'EOF'
+Usage: Alltest-regression [-j [N]]
+
+Run the tutorial regression tests in parallel.
+
+  -j [N]  Limit the number of parallel jobs. If N is omitted, use all
+          available cores.
+EOF
+}
+
+get_num_cores()
+{
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+    elif command -v getconf >/dev/null 2>&1; then
+        getconf _NPROCESSORS_ONLN
+    else
+        sysctl -n hw.ncpu
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -j)
+            if [[ $# -gt 1 && "$2" != -* ]]; then
+                MAX_JOBS="$2"
+                shift 2
+            else
+                MAX_JOBS="auto"
+                shift
+            fi
+            ;;
+        -j*)
+            MAX_JOBS="${1#-j}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+clean_copied_case_artifacts()
+{
+    local dir="$1"
+
+    find "$dir" -type f -name "log.*" -delete
+    find "$dir" -type d \( -name postProcessing -o -name dynamicCode -o -name "processor*" -o -name regressionTests -o -name VTKs -o -name VTK \) -prune -exec rm -rf {} +
+}
+
+rm -rf "${REG_ROOT}"
+mkdir -p "${REG_ROOT}"
+
+REGRESSION_TESTS=(
+    "laserbeamFoam/Plate2D"
+)
+
+failures=0
+if [[ -z "${MAX_JOBS}" || "${MAX_JOBS}" == "auto" ]]; then
+    MAX_JOBS="$(get_num_cores)"
+fi
+
+if ! [[ "${MAX_JOBS}" =~ ^[0-9]+$ ]] || [[ "${MAX_JOBS}" -lt 1 ]]; then
+    echo "Invalid job limit: ${MAX_JOBS}" >&2
+    exit 1
+fi
+
+echo "Using up to ${MAX_JOBS} parallel job(s)"
+
+run_regression_test()
+{
+    local test_case="$1"
+    local src_case="${ROOT_DIR}/${test_case}"
+    local dst_case="${REG_ROOT}/${test_case}"
+    local log_file="${REG_ROOT}/$(echo "${test_case}" | tr '/' '_').log"
+    local status_file="${REG_ROOT}/$(echo "${test_case}" | tr '/' '_').status"
+    local status=0
+
+    echo
+    echo "------------------------------------------------------------"
+    echo "Running regression test: ${test_case}"
+    echo "------------------------------------------------------------"
+
+    set +e
+    {
+        rm -rf "${dst_case}"
+        mkdir -p "$(dirname "${dst_case}")"
+        cp -a "${src_case}" "${dst_case}"
+        clean_copied_case_artifacts "${dst_case}"
+
+        cd "${dst_case}"
+
+        if [[ ! -x ./regressionTest.sh ]]; then
+            echo "FAIL: regressionTest.sh not found or not executable in ${test_case}"
+            return 1
+        fi
+
+        ./regressionTest.sh
+    } > "${log_file}" 2>&1
+    status=$?
+    set -e
+
+    echo "${status}" > "${status_file}"
+}
+
+active_jobs=0
+pids=()
+
+wait_for_available_slot()
+{
+    while (( active_jobs >= MAX_JOBS )); do
+        local live_pids=()
+
+        for pid in "${pids[@]}"; do
+            if kill -0 "${pid}" 2>/dev/null; then
+                live_pids+=("${pid}")
+            else
+                active_jobs=$((active_jobs - 1))
+            fi
+        done
+
+        if (( ${#live_pids[@]} > 0 )); then
+            pids=("${live_pids[@]}")
+        else
+            pids=()
+        fi
+
+        if (( active_jobs >= MAX_JOBS )); then
+            sleep 1
+        fi
+    done
+}
+
+for test_case in "${REGRESSION_TESTS[@]}"; do
+    wait_for_available_slot
+    run_regression_test "${test_case}" &
+    pids+=("$!")
+    active_jobs=$((active_jobs + 1))
+done
+
+wait
+
+for test_case in "${REGRESSION_TESTS[@]}"; do
+    log_file="${REG_ROOT}/$(echo "${test_case}" | tr '/' '_').log"
+    status_file="${REG_ROOT}/$(echo "${test_case}" | tr '/' '_').status"
+
+    echo
+    echo "------------------------------------------------------------"
+    echo "Regression test: ${test_case}"
+    echo "------------------------------------------------------------"
+
+    cat "${log_file}"
+
+    if [[ -f "${status_file}" ]] && [[ "$(cat "${status_file}")" == "0" ]]; then
+        echo "Result: PASS"
+    else
+        echo "Result: FAIL"
+        failures=$((failures + 1))
+    fi
+done
+
+echo
+if (( failures == 0 )); then
+    echo "============================================================"
+    echo "All regression tests PASSED"
+    echo "============================================================"
+    exit 0
+else
+    echo "============================================================"
+    echo "Regression suite FAILED (${failures} case(s))"
+    echo "============================================================"
+    exit 1
+fi

--- a/tutorials/laserbeamFoam/Plate2D/README.md
+++ b/tutorials/laserbeamFoam/Plate2D/README.md
@@ -1,0 +1,35 @@
+# `Plate2D` regression test
+
+This tutorial includes a lightweight regression script:
+
+```bash
+./regressionTest.sh
+```
+
+The regression test is intended to provide a quick check of the `laserbeamFoam`
+thermal and ray-tracing path without running the full tutorial duration.
+
+## What the script does
+
+- copies the tutorial into `regressionTests/main`
+- reduces the case `endTime` from `0.01` to `0.001`
+- appends a `fieldMinMax` function object for `T`
+- runs `./Allrun` in the copied case
+- checks a few final values against expected ranges
+
+## Current checks
+
+- final maximum temperature, extracted from
+  `postProcessing/TMinMax/0/fieldMinMax.dat`
+- final deposited heat reported for `laser0` in `log.laserbeamFoam`
+- final deposited heat reported for `laser1` in `log.laserbeamFoam`
+
+These checks are intentionally simple and cheap: they verify that the shortened
+case still produces the expected heating response and ray-tracing deposition.
+
+## Notes
+
+- The original tutorial files are not modified during the regression run; all
+  changes are made in the copied case under `regressionTests/`.
+- You can run the script with `--check-only` to skip rerunning the case and
+  only evaluate previously generated regression outputs.

--- a/tutorials/laserbeamFoam/Plate2D/regressionTest.sh
+++ b/tutorials/laserbeamFoam/Plate2D/regressionTest.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REGRESSION_ROOT="${SCRIPT_DIR}/regressionTests"
+CASE_DIR="${REGRESSION_ROOT}/main"
+
+# ============================================================
+# Plate2D regression test
+# Uses a shortened run and checks the final peak temperature and
+# deposited laser power to confirm the thermal/ray-tracing path.
+# ============================================================
+
+REG_END_TIME=0.001
+
+T_MAX_MIN=4375
+T_MAX_MAX=4390
+Q0_MIN=318
+Q0_MAX=320
+Q1_MIN=426
+Q1_MAX=429
+
+ALLRUN_LOGFILE="log.Allrun"
+SOLVER_LOGFILE="log.laserbeamFoam"
+T_MINMAX_FILE="postProcessing/TMinMax/0/fieldMinMax.dat"
+
+echo "============================================================"
+echo "Plate2D regression test"
+echo "Regression end time = ${REG_END_TIME}"
+echo "Final max(T) in [${T_MAX_MIN}, ${T_MAX_MAX}] K"
+echo "Final laser0 Q in [${Q0_MIN}, ${Q0_MAX}]"
+echo "Final laser1 Q in [${Q1_MIN}, ${Q1_MAX}]"
+echo "============================================================"
+echo
+
+prepare_case() {
+    rm -rf "${CASE_DIR}"
+    mkdir -p "${CASE_DIR}"
+
+    for item in "${SCRIPT_DIR}"/*; do
+        base_item=$(basename "${item}")
+        if [[ "${base_item}" == "regressionTests" ]]; then
+            continue
+        fi
+        cp -a "${item}" "${CASE_DIR}/"
+    done
+}
+
+shorten_case() {
+    local control_dict="${CASE_DIR}/system/controlDict"
+
+    sed -i.bak "s/^endTime.*/endTime         ${REG_END_TIME};/" "${control_dict}"
+    rm -f "${control_dict}.bak"
+
+    cat >> "${control_dict}" <<'EOF'
+
+functions
+{
+    TMinMax
+    {
+        type            fieldMinMax;
+        libs            ("libfieldFunctionObjects.so");
+        fields          (T);
+        writeControl    timeStep;
+        writeInterval   1;
+        write           true;
+        log             false;
+        mode            magnitude;
+    }
+}
+EOF
+}
+
+extract_final_tmax() {
+    awk -F '\t+' 'END {print $5}' "${CASE_DIR}/${T_MINMAX_FILE}"
+}
+
+extract_final_q_values() {
+    awk '/Total Q deposited:/ {print $4}' "${CASE_DIR}/${SOLVER_LOGFILE}" | tail -n 2
+}
+
+CHECK_ONLY=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --check-only|--no-run)
+            CHECK_ONLY=true
+            ;;
+        *)
+            ;;
+    esac
+done
+
+if [ "${CHECK_ONLY}" = false ]; then
+    prepare_case
+    shorten_case
+    ( cd "${CASE_DIR}" && ./Allclean > /dev/null 2>&1 ) || true
+    ( cd "${CASE_DIR}" && ./Allrun > "${ALLRUN_LOGFILE}" 2>&1 )
+else
+    echo "Running in check-only mode: skipping Allclean and Allrun"
+fi
+
+if [[ ! -f "${CASE_DIR}/${T_MINMAX_FILE}" ]]; then
+    echo "FAIL: Could not find ${T_MINMAX_FILE}"
+    exit 1
+fi
+
+if [[ ! -f "${CASE_DIR}/${SOLVER_LOGFILE}" ]]; then
+    echo "FAIL: Could not find ${SOLVER_LOGFILE}"
+    exit 1
+fi
+
+final_tmax=$(extract_final_tmax)
+
+q_values=($(extract_final_q_values))
+final_q0="${q_values[0]:-}"
+final_q1="${q_values[1]:-}"
+
+if [[ -z "${final_tmax}" || -z "${final_q0}" || -z "${final_q1}" ]]; then
+    echo "FAIL: Could not extract one or more regression values"
+    exit 1
+fi
+
+failures=0
+
+if awk "BEGIN {exit !(${final_tmax} >= ${T_MAX_MIN} && ${final_tmax} <= ${T_MAX_MAX})}"; then
+    printf "PASS: Final max(T) = %.6f K\n" "${final_tmax}"
+else
+    printf "FAIL: Final max(T) = %.6f K\n" "${final_tmax}"
+    failures=$((failures + 1))
+fi
+
+if awk "BEGIN {exit !(${final_q0} >= ${Q0_MIN} && ${final_q0} <= ${Q0_MAX})}"; then
+    printf "PASS: Final laser0 Q = %.6f\n" "${final_q0}"
+else
+    printf "FAIL: Final laser0 Q = %.6f\n" "${final_q0}"
+    failures=$((failures + 1))
+fi
+
+if awk "BEGIN {exit !(${final_q1} >= ${Q1_MIN} && ${final_q1} <= ${Q1_MAX})}"; then
+    printf "PASS: Final laser1 Q = %.6f\n" "${final_q1}"
+else
+    printf "FAIL: Final laser1 Q = %.6f\n" "${final_q1}"
+    failures=$((failures + 1))
+fi
+
+if [ "${CHECK_ONLY}" = false ]; then
+    ( cd "${CASE_DIR}" && ./Allclean > /dev/null 2>&1 ) || true
+fi
+
+echo
+if (( failures == 0 )); then
+    echo "============================================================"
+    echo "Regression test PASSED"
+    echo "============================================================"
+    exit 0
+else
+    echo "============================================================"
+    echo "Regression test FAILED (${failures} checks)"
+    echo "============================================================"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds two related pieces of repo support:

1. A repo-local Codex skill for `LaserbeamFoam`
2. An initial regression-test harness for the tutorials, starting with `tutorials/laserbeamFoam/Plate2D`

It also updates the GitHub Actions build workflow so the new regression suite is exercised automatically in CI.

## Changes

- add repo-local skill files under `.agents/skills/laserbeamfoam/`
- document the Codex skill in the top-level `README.md`
- add `tutorials/laserbeamFoam/Plate2D/regressionTest.sh`
- add `tutorials/laserbeamFoam/Plate2D/README.md` describing the regression test
- add `tutorials/Alltest-regression` as a top-level regression driver
- update `.github/workflows/build.yml` to run `tutorials/Alltest-regression`
- ignore generated regression run directories in `.gitignore`

## Regression test approach

The new `Plate2D` regression script follows the same general style as the regression scripts used in `solids4foam`:

- copy the case into a separate regression working directory
- shorten the run to reduce turnaround time
- add a lightweight function object in the copied case only
- run the case and check a few stable output quantities against expected ranges

For `Plate2D`, the script shortens `endTime` from `0.01` to `0.001` and checks:

- final maximum temperature from `postProcessing/TMinMax/0/fieldMinMax.dat`
- final deposited heat for `laser0` from `log.laserbeamFoam`
- final deposited heat for `laser1` from `log.laserbeamFoam`

## CI

The GitHub Actions workflow in `.github/workflows/build.yml` now runs:

- `./Alltest`
- `./Alltest-regression -j1`

This means the initial regression suite is exercised automatically for pull requests and pushes on the OpenFOAM.com CI configuration.

## How to run

Run the individual case regression:

```bash
cd tutorials/laserbeamFoam/Plate2D
./regressionTest.sh
```

Run the top-level regression driver:

```bash
cd tutorials
./Alltest-regression -j1
```

or with more parallelism, for example:

```bash
./Alltest-regression -j4
```

## Notes

This is intended as an initial pattern that can be extended to other tutorials. We can use the same style for additional cases by selecting a short but representative runtime window and checking one or more stable output quantities from a function object or the solver log.
