### PR TITLE
Add ray bounce guard for laser tracing

### DIFF
--- a/src/laserHeatSource/laserHeatSource.C
+++ b/src/laserHeatSource/laserHeatSource.C
@@ -736,7 +736,7 @@ void laserHeatSource::updateDeposition
         );
         const word maxRayBounceAction
         (
-            dict.lookupOrDefault<word>("maxRayBounceAction", "error")
+            dict.lookupOrDefault<word>("maxRayBounceAction", "deposit")
         );
         const scalar nearZeroAbsorptivityTol
         (

--- a/src/laserHeatSource/laserHeatSource.C
+++ b/src/laserHeatSource/laserHeatSource.C
@@ -728,11 +728,11 @@ void laserHeatSource::updateDeposition
         );
         const scalar rayPowerRelTol
         (
-            dict.lookupOrDefault<scalar>("rayPowerRelTol", 1e-6)
+            dict.lookupOrDefault<scalar>("rayPowerRelTol", 1e-4)
         );
         const label maxRayBounces
         (
-            dict.lookupOrDefault<label>("maxRayBounces", 10000)
+            dict.lookupOrDefault<label>("maxRayBounces", 1000)
         );
         const word maxRayBounceAction
         (

--- a/src/laserHeatSource/laserHeatSource.C
+++ b/src/laserHeatSource/laserHeatSource.C
@@ -730,6 +730,18 @@ void laserHeatSource::updateDeposition
         (
             dict.lookupOrDefault<scalar>("rayPowerRelTol", 1e-6)
         );
+        const label maxRayBounces
+        (
+            dict.lookupOrDefault<label>("maxRayBounces", 10000)
+        );
+        const word maxRayBounceAction
+        (
+            dict.lookupOrDefault<word>("maxRayBounceAction", "error")
+        );
+        const scalar nearZeroAbsorptivityTol
+        (
+            dict.lookupOrDefault<scalar>("nearZeroAbsorptivityTol", SMALL)
+        );
 
         updateDeposition
         (
@@ -751,6 +763,9 @@ void laserHeatSource::updateDeposition
             useLocalSearch,
             maxLocalSearch,
             rayPowerRelTol,
+            maxRayBounces,
+            maxRayBounceAction,
+            nearZeroAbsorptivityTol,
             globalBB_
         );
     }
@@ -793,6 +808,9 @@ void laserHeatSource::updateDeposition
     const Switch useLocalSearch,
     const label maxLocalSearch,
     const scalar rayPowerRelTol,
+    const label maxRayBounces,
+    const word& maxRayBounceAction,
+    const scalar nearZeroAbsorptivityTol,
     const boundBox& globalBB
 )
 {
@@ -871,6 +889,11 @@ void laserHeatSource::updateDeposition
 
     DynamicList<label> finishedRayIDs;
     DynamicList<DynamicList<point>> finishedRayPaths;
+    label maxBounceTerminations = 0;
+    scalar maxBounceResidualPower = 0.0;
+    scalar minAbsorptivity = GREAT;
+    label nearZeroAbsorptivityCount = 0;
+    label maxObservedBounces = 0;
 
     laserRayParticle::trackingData td
     (
@@ -885,6 +908,14 @@ void laserHeatSource::updateDeposition
         plasma_frequency,
         angular_frequency,
         rayPowerAbsTol,
+        maxRayBounces,
+        maxRayBounceAction,
+        nearZeroAbsorptivityTol,
+        maxBounceTerminations,
+        maxBounceResidualPower,
+        minAbsorptivity,
+        nearZeroAbsorptivityCount,
+        maxObservedBounces,
         finishedRayIDs,
         finishedRayPaths
     );
@@ -895,6 +926,12 @@ void laserHeatSource::updateDeposition
     // the rays are tracked to completion in a single call.
     rayCloud.storeGlobalPositions();
     rayCloud.move(rayCloud, td, GREAT);
+
+    reduce(maxBounceTerminations, sumOp<label>());
+    reduce(maxBounceResidualPower, sumOp<scalar>());
+    reduce(minAbsorptivity, minOp<scalar>());
+    reduce(nearZeroAbsorptivityCount, sumOp<label>());
+    reduce(maxObservedBounces, maxOp<label>());
 
     // ==================================================================
     // Step 4: Gather ray path segments to master for VTK output
@@ -970,6 +1007,27 @@ void laserHeatSource::updateDeposition
 
     const scalar TotalQ = fvc::domainIntegrate(deposition_).value();
     Info<< "    Total Q deposited: " << TotalQ << endl;
+
+    if (maxBounceTerminations > 0)
+    {
+        Info<< "    Ray-tracing safety diagnostics:" << nl
+            << "        maxRayBounces = " << maxRayBounces << nl
+            << "        maxRayBounceAction = " << maxRayBounceAction << nl
+            << "        max observed bounces = " << maxObservedBounces << nl
+            << "        rays handled by maxRayBounces = "
+            << maxBounceTerminations << nl
+            << "        residual power handled by maxRayBounces = "
+            << maxBounceResidualPower << nl
+            << "        residual fraction of current laser power = "
+            << maxBounceResidualPower/(mag(currentLaserPower) + VSMALL) << nl
+            << "        minimum Fresnel absorptivity encountered = "
+            << (minAbsorptivity == GREAT ? scalar(-1) : minAbsorptivity)
+            << nl
+            << "        near-zero absorptivity interactions = "
+            << nearZeroAbsorptivityCount << nl
+            << "        near-zero absorptivity tolerance = "
+            << nearZeroAbsorptivityTol << endl;
+    }
 }
 
 

--- a/src/laserHeatSource/laserHeatSource.C
+++ b/src/laserHeatSource/laserHeatSource.C
@@ -870,11 +870,6 @@ void laserHeatSource::updateDeposition
         nTotalRays
     );
 
-    // Compute absolute power tolerance from relative tolerance
-    // (Based on average ray power, not total power)
-    const scalar rayPowerAbsTol =
-        rayPowerRelTol*currentLaserPower/max(nTotalRays, 1);
-
     // ==================================================================
     // Step 3: Move the particles through the mesh
     //
@@ -907,7 +902,7 @@ void laserHeatSource::updateDeposition
         dep_cutoff,
         plasma_frequency,
         angular_frequency,
-        rayPowerAbsTol,
+        rayPowerRelTol,
         maxRayBounces,
         maxRayBounceAction,
         nearZeroAbsorptivityTol,

--- a/src/laserHeatSource/laserHeatSource.H
+++ b/src/laserHeatSource/laserHeatSource.H
@@ -217,6 +217,9 @@ public:
             const Switch useLocalSearch,
             const label maxLocalSearch,
             const scalar rayPowerRelTol,
+            const label maxRayBounces,
+            const word& maxRayBounceAction,
+            const scalar nearZeroAbsorptivityTol,
             const boundBox& globalBB
         );
 

--- a/src/laserHeatSource/laserRayParticle.C
+++ b/src/laserHeatSource/laserRayParticle.C
@@ -55,6 +55,8 @@ Foam::laserRayParticle::laserRayParticle
     initialPower_(power),
     dA_(dA),
     bounceCount_(0),
+    minAbsorptivity_(GREAT),
+    nearZeroAbsorptivityCount_(0),
     globalRayIndex_(globalRayIndex),
     active_(true),
     path_()
@@ -77,6 +79,8 @@ Foam::laserRayParticle::laserRayParticle
     initialPower_(0),
     dA_(0),
     bounceCount_(0),
+    minAbsorptivity_(GREAT),
+    nearZeroAbsorptivityCount_(0),
     globalRayIndex_(-1),
     active_(true),
     path_()
@@ -88,6 +92,8 @@ Foam::laserRayParticle::laserRayParticle
             >> initialPower_
             >> dA_
             >> bounceCount_
+            >> minAbsorptivity_
+            >> nearZeroAbsorptivityCount_
             >> globalRayIndex_
             >> active_;
     }
@@ -176,7 +182,7 @@ bool Foam::laserRayParticle::move
             // Interface cell - Fresnel reflection/absorption
             // ================================================
 
-            const scalar absorptivity = computeFresnelAbsorptivity
+            const scalar fresnelAbsorptivity = computeFresnelAbsorptivity
             (
                 direction_,
                 nI[cellI],
@@ -185,11 +191,22 @@ bool Foam::laserRayParticle::move
                 td.resistivity_[cellI]
             );
 
+            minAbsorptivity_ =
+                min(minAbsorptivity_, fresnelAbsorptivity);
+            td.minAbsorptivity_ =
+                min(td.minAbsorptivity_, fresnelAbsorptivity);
+
+            if (fresnelAbsorptivity <= td.nearZeroAbsorptivityTol_)
+            {
+                nearZeroAbsorptivityCount_++;
+                td.nearZeroAbsorptivityCount_++;
+            }
+
             // Deposit absorbed fraction
-            td.deposition_[cellI] += absorptivity * power_ / VI[cellI];
+            td.deposition_[cellI] += fresnelAbsorptivity * power_ / VI[cellI];
 
             // Reduce ray power
-            power_ *= (1.0 - absorptivity);
+            power_ *= (1.0 - fresnelAbsorptivity);
 
             // Specular reflection about the interface normal
             vector n = nI[cellI];
@@ -205,7 +222,73 @@ bool Foam::laserRayParticle::move
             direction_ /= mag(direction_) + VSMALL;
 
             bounceCount_++;
+            td.maxObservedBounces_ =
+                max(td.maxObservedBounces_, bounceCount_);
             path_.append(position());
+
+            if (td.maxRayBounces_ > 0 && bounceCount_ >= td.maxRayBounces_)
+            {
+                const scalar residualPower = power_;
+
+                td.maxBounceTerminations_++;
+                td.maxBounceResidualPower_ += residualPower;
+
+                const word& action = td.maxRayBounceAction_;
+
+                if (action == "error")
+                {
+                    FatalErrorInFunction
+                        << "Ray " << globalRayIndex_
+                        << " exceeded maxRayBounces="
+                        << td.maxRayBounces_
+                        << " at position " << position()
+                        << ", cell " << cellI
+                        << ", residualPower=" << residualPower
+                        << ", initialPower=" << initialPower_
+                        << ", minAbsorptivity=" << minAbsorptivity_
+                        << ", nearZeroAbsorptivityCount="
+                        << nearZeroAbsorptivityCount_
+                        << ". Set maxRayBounceAction to escape or deposit "
+                        << "to continue explicitly."
+                        << exit(FatalError);
+                }
+                else if (action == "deposit")
+                {
+                    td.deposition_[cellI] += power_ / VI[cellI];
+                    power_ = 0.0;
+                }
+                else if (action == "escape" || action == "discard")
+                {
+                    power_ = 0.0;
+                }
+                else
+                {
+                    FatalErrorInFunction
+                        << "Unknown maxRayBounceAction '" << action
+                        << "'. Valid options are error, escape, discard, "
+                        << "deposit."
+                        << exit(FatalError);
+                }
+
+                WarningInFunction
+                    << "Terminating ray " << globalRayIndex_
+                    << " after maxRayBounces=" << td.maxRayBounces_
+                    << " with action=" << action
+                    << " at position " << position()
+                    << ", cell " << cellI
+                    << ", residualPower=" << residualPower
+                    << ", initialPower=" << initialPower_
+                    << ", minAbsorptivity=" << minAbsorptivity_
+                    << ", nearZeroAbsorptivityCount="
+                    << nearZeroAbsorptivityCount_
+                    << endl;
+
+                td.finishedRayIDs_.append(globalRayIndex_);
+                td.finishedRayPaths_.append(path_);
+                active_ = false;
+                td.keepParticle = false;
+                break;
+            }
 
             // If power is now below tolerance, kill the ray
             if (power_ < td.rayPowerAbsTol_)
@@ -475,6 +558,20 @@ void Foam::laserRayParticle::readFields
     );
     cloud.checkFieldIOobject(cloud, bounceCount);
 
+    IOField<scalar> minAbsorptivity
+    (
+        cloud.newIOobject("minAbsorptivity", IOobject::MUST_READ),
+        valid
+    );
+    cloud.checkFieldIOobject(cloud, minAbsorptivity);
+
+    IOField<label> nearZeroAbsorptivityCount
+    (
+        cloud.newIOobject("nearZeroAbsorptivityCount", IOobject::MUST_READ),
+        valid
+    );
+    cloud.checkFieldIOobject(cloud, nearZeroAbsorptivityCount);
+
     IOField<label> globalRayIndex
     (
         cloud.newIOobject("globalRayIndex", IOobject::MUST_READ),
@@ -490,6 +587,8 @@ void Foam::laserRayParticle::readFields
         p.initialPower_ = initialPower[i];
         p.dA_ = dA[i];
         p.bounceCount_ = bounceCount[i];
+        p.minAbsorptivity_ = minAbsorptivity[i];
+        p.nearZeroAbsorptivityCount_ = nearZeroAbsorptivityCount[i];
         p.globalRayIndex_ = globalRayIndex[i];
         ++i;
     }
@@ -530,6 +629,16 @@ void Foam::laserRayParticle::writeFields
         cloud.newIOobject("bounceCount", IOobject::NO_READ),
         np
     );
+    IOField<scalar> minAbsorptivity
+    (
+        cloud.newIOobject("minAbsorptivity", IOobject::NO_READ),
+        np
+    );
+    IOField<label> nearZeroAbsorptivityCount
+    (
+        cloud.newIOobject("nearZeroAbsorptivityCount", IOobject::NO_READ),
+        np
+    );
     IOField<label> globalRayIndex
     (
         cloud.newIOobject("globalRayIndex", IOobject::NO_READ),
@@ -544,6 +653,8 @@ void Foam::laserRayParticle::writeFields
         initialPower[i] = p.initialPower_;
         dA[i] = p.dA_;
         bounceCount[i] = p.bounceCount_;
+        minAbsorptivity[i] = p.minAbsorptivity_;
+        nearZeroAbsorptivityCount[i] = p.nearZeroAbsorptivityCount_;
         globalRayIndex[i] = p.globalRayIndex_;
         ++i;
     }
@@ -553,6 +664,8 @@ void Foam::laserRayParticle::writeFields
     initialPower.write(np > 0);
     dA.write(np > 0);
     bounceCount.write(np > 0);
+    minAbsorptivity.write(np > 0);
+    nearZeroAbsorptivityCount.write(np > 0);
     globalRayIndex.write(np > 0);
 }
 
@@ -571,6 +684,8 @@ Foam::Ostream& Foam::operator<<
         << token::SPACE << p.initialPower_
         << token::SPACE << p.dA_
         << token::SPACE << p.bounceCount_
+        << token::SPACE << p.minAbsorptivity_
+        << token::SPACE << p.nearZeroAbsorptivityCount_
         << token::SPACE << p.globalRayIndex_
         << token::SPACE << p.active_;
 

--- a/src/laserHeatSource/laserRayParticle.C
+++ b/src/laserHeatSource/laserRayParticle.C
@@ -159,8 +159,8 @@ bool Foam::laserRayParticle::move
         td.rayQ_[cellI] += power_;
         td.rayNumber_[cellI] = globalRayIndex_;
 
-        // Check if power is exhausted
-        if (power_ < td.rayPowerAbsTol_ || power_ < SMALL)
+        // Check if power is exhausted relative to this ray's initial power
+        if (power_ < td.rayPowerRelTol_*initialPower_ || power_ < SMALL)
         {
             path_.append(position());
             td.finishedRayIDs_.append(globalRayIndex_);
@@ -291,7 +291,7 @@ bool Foam::laserRayParticle::move
             }
 
             // If power is now below tolerance, kill the ray
-            if (power_ < td.rayPowerAbsTol_)
+            if (power_ < td.rayPowerRelTol_*initialPower_)
             {
                 td.finishedRayIDs_.append(globalRayIndex_);
                 td.finishedRayPaths_.append(path_);

--- a/src/laserHeatSource/laserRayParticle.H
+++ b/src/laserHeatSource/laserRayParticle.H
@@ -143,8 +143,8 @@ public:
             //- Angular frequency of laser light [rad/s]
             scalar angularFrequency_;
 
-            //- Ray power absolute tolerance [W]
-            scalar rayPowerAbsTol_;
+            //- Ray power tolerance relative to each ray's initial power
+            scalar rayPowerRelTol_;
 
             //- Maximum number of reflections before handling a ray
             label maxRayBounces_;
@@ -190,7 +190,7 @@ public:
             const scalar depCutoff,
             const scalar plasmaFrequency,
             const scalar angularFrequency,
-            const scalar rayPowerAbsTol,
+            const scalar rayPowerRelTol,
             const label maxRayBounces,
             const word& maxRayBounceAction,
             const scalar nearZeroAbsorptivityTol,
@@ -213,7 +213,7 @@ public:
             depCutoff_(depCutoff),
             plasmaFrequency_(plasmaFrequency),
             angularFrequency_(angularFrequency),
-            rayPowerAbsTol_(rayPowerAbsTol),
+            rayPowerRelTol_(rayPowerRelTol),
             maxRayBounces_(maxRayBounces),
             maxRayBounceAction_(maxRayBounceAction),
             nearZeroAbsorptivityTol_(nearZeroAbsorptivityTol),

--- a/src/laserHeatSource/laserRayParticle.H
+++ b/src/laserHeatSource/laserRayParticle.H
@@ -91,6 +91,12 @@ public:
         //- Number of reflections
         label bounceCount_;
 
+        //- Smallest absorptivity encountered by this ray
+        scalar minAbsorptivity_;
+
+        //- Number of near-zero absorptivity reflections seen by this ray
+        label nearZeroAbsorptivityCount_;
+
         //- Global ray index (for VTK output ordering)
         label globalRayIndex_;
 
@@ -140,6 +146,30 @@ public:
             //- Ray power absolute tolerance [W]
             scalar rayPowerAbsTol_;
 
+            //- Maximum number of reflections before handling a ray
+            label maxRayBounces_;
+
+            //- Action when maxRayBounces is exceeded
+            word maxRayBounceAction_;
+
+            //- Ray absorptivity below this value is counted as near-zero
+            scalar nearZeroAbsorptivityTol_;
+
+            //- Number of rays handled by maxRayBounces on this rank
+            label& maxBounceTerminations_;
+
+            //- Residual ray power handled by maxRayBounces on this rank
+            scalar& maxBounceResidualPower_;
+
+            //- Smallest absorptivity encountered on this rank
+            scalar& minAbsorptivity_;
+
+            //- Number of near-zero absorptivity interactions on this rank
+            label& nearZeroAbsorptivityCount_;
+
+            //- Largest bounce count encountered on this rank
+            label& maxObservedBounces_;
+
             //- Collected ray paths from finished particles
             //  (particles store their paths here before dying,
             //   since dead particles are removed from the cloud)
@@ -161,6 +191,14 @@ public:
             const scalar plasmaFrequency,
             const scalar angularFrequency,
             const scalar rayPowerAbsTol,
+            const label maxRayBounces,
+            const word& maxRayBounceAction,
+            const scalar nearZeroAbsorptivityTol,
+            label& maxBounceTerminations,
+            scalar& maxBounceResidualPower,
+            scalar& minAbsorptivity,
+            label& nearZeroAbsorptivityCount,
+            label& maxObservedBounces,
             DynamicList<label>& finishedRayIDs,
             DynamicList<DynamicList<point>>& finishedRayPaths
         )
@@ -176,6 +214,14 @@ public:
             plasmaFrequency_(plasmaFrequency),
             angularFrequency_(angularFrequency),
             rayPowerAbsTol_(rayPowerAbsTol),
+            maxRayBounces_(maxRayBounces),
+            maxRayBounceAction_(maxRayBounceAction),
+            nearZeroAbsorptivityTol_(nearZeroAbsorptivityTol),
+            maxBounceTerminations_(maxBounceTerminations),
+            maxBounceResidualPower_(maxBounceResidualPower),
+            minAbsorptivity_(minAbsorptivity),
+            nearZeroAbsorptivityCount_(nearZeroAbsorptivityCount),
+            maxObservedBounces_(maxObservedBounces),
             finishedRayIDs_(finishedRayIDs),
             finishedRayPaths_(finishedRayPaths)
         {}


### PR DESCRIPTION
Summary:
- Add configurable maxRayBounces guard for laser ray tracing, defaulting to 1000.
- Add maxRayBounceAction, defaulting to deposit, plus explicit error, escape, and discard actions.
- Interpret rayPowerRelTol relative to each ray's own initial power instead of the average ray power, defaulting to 1e-4.
- Report diagnostics only when the bounce guard is triggered, including residual power, minimum Fresnel absorptivity, near-zero absorptivity interactions, and max observed bounces.

Background:
I ran into a case where laserbeamFoam appeared to hang during ray tracing. The solver reached Updating deposition and printed the number of rays, but never reached Total Q deposited. A diagnostic version showed that one ray could keep reflecting with a nearly zero Fresnel absorptivity. In the reproducer, the minimum Fresnel absorptivity reached about 6.7e-16, so the ray retained a significant fraction of its initial power even after many reflections.

Patrick pointed out that a fixed bounce count should not be the main physical termination criterion. The important quantity is how much power remains in the ray. For strongly absorbing materials, even a modest number of bounces may leave only a negligible residual power, so continuing to trace the ray wastes wall time. For weakly absorbing materials, however, the same number of bounces may still leave a significant fraction of the ray power, so terminating only by bounce count could remove physically relevant energy.

Implementation:
This PR integrates that suggestion by making rayPowerRelTol a true per-ray relative power criterion. Instead of converting it to an absolute tolerance using the average ray power, each ray is now terminated when

    current ray power < rayPowerRelTol * initial ray power

The default rayPowerRelTol is 1e-4, meaning a ray is normally stopped once it has less than 0.01% of its own initial power left. This makes the normal termination criterion independent of the ray's initial weighting, which is important for non-uniform/Gaussian ray power distributions.

The maxRayBounces option is kept as a last-resort safety guard, not as the primary physics criterion. It handles pathological cases where the ray power does not decay because the absorptivity remains close to zero. The default maxRayBounces is 1000. By default, if the guard is reached, the residual ray power is deposited in the current cell and a warning plus summary diagnostics are printed. Users can explicitly choose error, escape, or discard instead.

Why keep both criteria:
- rayPowerRelTol handles the common case: rays whose residual power has become negligible.
- maxRayBounces handles the pathological case: rays that continue reflecting without losing meaningful power.

Diagnostics:
When the bounce guard is triggered, the solver reports the number of affected rays, the residual power handled by the guard, the residual fraction of the current laser power, the minimum Fresnel absorptivity encountered, and the number of near-zero absorptivity interactions. This should make it visible when the safety guard affects a run.

Testing:
- git diff --check passed locally.
- Verified on a reproducer case that maxRayBounceAction deposit terminates a trapped ray and reports diagnostics instead of hanging.